### PR TITLE
editar usuarios y fix en user_in_requests#index

### DIFF
--- a/app/views/user_in_requests/index.html.erb
+++ b/app/views/user_in_requests/index.html.erb
@@ -17,8 +17,8 @@
   <tbody>
     <% @user_in_requests.each do |user_in_request| %>
       <tr>
-        <td><%= user_in_request.user_id %></td>
-        <td><%= user_in_request.request_id %></td>
+        <td><%= user_in_request.user.name %></td>
+        <td><%= user_in_request.request.course.name %></td>
         <td><%= link_to 'Mostrar', user_in_request %></td>
         <td><%= link_to 'Editar', edit_user_in_request_path(user_in_request) %></td>
         <td><%= link_to 'Borrar', user_in_request, method: :delete, data: { confirm: '¿Borrar usuario de la propuesta?' } %></td>

--- a/app/views/users/_form_edit.html.erb
+++ b/app/views/users/_form_edit.html.erb
@@ -38,8 +38,9 @@
     <%= f.label :Informacion_Adicional %><br />
     <%= f.text_field :informacion_adicional %>
   </p>
-		Para hacer los cambios ingrese su contraseña (tambien la puede cambiar).
-	</p>
+ <% if @user == current_user %>
+	<b> ** Para hacer los cambios ingrese su contraseña (tambien la puede cambiar). ** </b>
+	<p>
     <%= f.label :Contraseña %><br />
     <%= f.password_field :password %>
   </p>
@@ -47,6 +48,40 @@
     <%= f.label :Confirmar_Contraseña%><br />
     <%= f.password_field :password_confirmation %>
   </p>
+  <% else %>
+  <b>** Asegurese de colocar el rol y la carrera antes de presionar el boton de 'Editar' **</b>
+  <p>
+    <%= f.label :Rol %><br />
+    <select name="user[role_id]">
+      <% if !userIsCoordinator %>
+        <% Role.all.each do |r| %>
+          <option value="<%= r.id %>"><%= r.name %></option>
+        <% end %> 
+      <% else %>
+        <% Role.where.not(id:2).each do |r| %>
+          <option value="<%= r.id %>"><%= r.name %></option>
+        <% end %> 
+      <% end %>
+    </select>
+  </p>
+  <% if userIsAdmin %>
+	<p>
+    <%= f.label :Carrera %><br />
+    <% if !userIsCoordinator %>
+      <select name="user[career_id]">
+        <% Career.all.each do |c| %>
+          <option value="<%= c.id %>"><%= c.name %></option>
+        <% end %>
+      </select>
+    <% else %>
+      <%= f.hidden_field :career_id, {:value => current_user.career_id, :name => 'user[career_id]'} %>				
+			<%= current_user.career.name %>
+    <% end %>
+  </p>
+  <% end %>
+    <%= f.hidden_field :password, {:value => @user.password, :name => 'user[password]'} %>
+    <%= f.hidden_field :password_confirmation, {:value => @user.password_confirmation, :name => 'user[password_confirmation]'} %>
+  <% end %>
 	<% end %>
   <p ><%= f.submit 'Editar' %></p>
   

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,6 +30,16 @@
   <%= @user.informacion_adicional %>
 </p>
 
+<p>
+  <strong>Carrera:</strong>
+  <%= @user.career.name %>
+</p>
+
+<p>
+  <strong>Rol:</strong>
+  <%= @user.role.name %>
+</p>
+
 <%= link_to 'Editar', edit_user_path(@user) %> |
 <%= link_to 'Regresar', "/users" %>
 <% else %>


### PR DESCRIPTION
Incluye:
- Mostrar nombre de usuario y clase en user_in_requests#index (ya no muestra id).
- Al editarse uno mismo, el formato es el mismo, pero al editar otros usuarios, la contrasena del usuario se mantiene.
- Si es admin, puede editar los roles y carreras de los demas usuarios.
- Si es coordinador, solamente puede editar los roles.
